### PR TITLE
Add tests for spread module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,14 +13,10 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.10
     hooks:
-      # Sort imports
-      - id: ruff
-        args: ["check", "--select", "I", "--fix"]
         # lint
-      - id: ruff
+      - id: ruff-check
         # format
       - id: ruff-format
-        args: ["--line-length", "79"]
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.8.13
     hooks:

--- a/polarbayes/spread.py
+++ b/polarbayes/spread.py
@@ -5,7 +5,8 @@ import numpy as np
 import pandas as pd
 import polars as pl
 import polars.selectors as cs
-from polarbayes.schema import order_index_column_names, CHAIN_NAME, DRAW_NAME
+
+from polarbayes.schema import CHAIN_NAME, DRAW_NAME, order_index_column_names
 
 
 def spread_draws_to_pandas_(

--- a/polarbayes/spread.py
+++ b/polarbayes/spread.py
@@ -4,6 +4,8 @@ import arviz as az
 import numpy as np
 import pandas as pd
 import polars as pl
+import polars.selectors as cs
+from polarbayes.schema import order_index_column_names, CHAIN_NAME, DRAW_NAME
 
 
 def spread_draws_to_pandas_(
@@ -63,7 +65,7 @@ def spread_draws_to_pandas_(
         rng=rng,
     ).to_dataframe()
     if combined:
-        df = df.drop(["chain", "draw"], axis=1)
+        df = df.drop([CHAIN_NAME, DRAW_NAME], axis=1)
         # az.extract with combined=True assumes that the InferenceData
         # object has "chain" and "draw" named dimensions and errors otherwise.
         # When the resultant dataset is converted to a pandas dataframe
@@ -139,12 +141,21 @@ def spread_draws_and_get_index_cols(
         rng=rng,
     )
     if enforce_drop_chain_draw:
-        df = df.drop(["chain", "draw"], axis=1)
+        df = df.drop([CHAIN_NAME, DRAW_NAME], axis=1)
         # this is handled automatically when `combined=True`
         # by spread_draws_to_pandas_,
         # but not when combined=False but the `data` input
         # is an already-combined output of `az.extract`.
-    return (pl.DataFrame(df.reset_index()), tuple(df.index.names))
+    df, index_cols = pl.DataFrame(df.reset_index()), df.index.names
+    index_cols_ordered = order_index_column_names(index_cols)
+
+    return (
+        df.select(
+            cs.by_name(index_cols_ordered, require_all=True),
+            cs.exclude(index_cols_ordered),
+        ),
+        index_cols_ordered,
+    )
 
 
 def spread_draws(

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,1 @@
+line-length = 79

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,1 +1,2 @@
 line-length = 79
+fix = true

--- a/test/test_spread.py
+++ b/test/test_spread.py
@@ -26,9 +26,7 @@ def test_spread_wraps_spread_with_index(spread_args, rng_seed):
     result, index = spread_draws_and_get_index_cols(
         rugby_field_data, **spread_args, rng=rng_index
     )
-    result_no_index = spread_draws(
-        rugby_field_data, **spread_args, rng=rng_no_index
-    )
+    result_no_index = spread_draws(rugby_field_data, **spread_args, rng=rng_no_index)
     assert result.equals(result_no_index)
     for col in index:
         assert col in result_no_index.columns

--- a/test/test_spread.py
+++ b/test/test_spread.py
@@ -1,6 +1,7 @@
 import arviz as az
 import numpy as np
 import pytest
+import pandas as pd
 
 from polarbayes.schema import CHAIN_NAME, DRAW_NAME
 
@@ -55,10 +56,13 @@ def test_spread_to_pandas(spread_args, rng_seed):
     expected = az.extract(
         rugby_field_data, **spread_args, rng=rng_extract
     ).to_dataframe()
+    # check that duplicated columns get dropped when required.
     if spread_args.get("combined", True):
         expected = expected.drop([CHAIN_NAME, DRAW_NAME], axis=1)
 
+    assert isinstance(result, pd.DataFrame)
     assert result.equals(expected)
+    # reserved names should always be present in index and never present as columns
     assert CHAIN_NAME in result.index.names
     assert DRAW_NAME in result.index.names
     assert CHAIN_NAME not in result.columns

--- a/test/test_spread.py
+++ b/test/test_spread.py
@@ -84,8 +84,14 @@ def test_spread_draws_and_get_index_columns(spread_args, rng_seed):
     # result index
     assert set(result_index) == set(pd_df.index.names)
     # result index should be returned already ordered according to the schema
+    # and result columns should follow the same order.
     ordered_index = order_index_column_names(result_index)
     assert result_index == ordered_index
+    expected_cols = (
+        ordered_index
+        + result_df.select(cs.exclude(result_index)).collect_schema().names()
+    )
+    assert result_df.columns == expected_cols
 
     assert result_df.equals(
         pl.DataFrame(pd_df.reset_index()).select(

--- a/test/test_spread.py
+++ b/test/test_spread.py
@@ -1,7 +1,6 @@
-import pytest
 import arviz as az
-import polars as pl
 import numpy as np
+import polars as pl
 import pytest
 
 from polarbayes.spread import spread_draws, spread_draws_and_get_index_cols
@@ -27,7 +26,9 @@ def test_spread_wraps_spread_with_index(spread_args, rng_seed):
     result, index = spread_draws_and_get_index_cols(
         rugby_field_data, **spread_args, rng=rng_index
     )
-    result_no_index = spread_draws(rugby_field_data, **spread_args, rng=rng_no_index)
+    result_no_index = spread_draws(
+        rugby_field_data, **spread_args, rng=rng_no_index
+    )
     assert result.equals(result_no_index)
     for col in index:
         assert col in result_no_index.columns

--- a/test/test_spread.py
+++ b/test/test_spread.py
@@ -59,6 +59,10 @@ def test_spread_to_pandas(spread_args, rng_seed):
         expected = expected.drop([CHAIN_NAME, DRAW_NAME], axis=1)
 
     assert result.equals(expected)
+    assert CHAIN_NAME in result.index.names
+    assert DRAW_NAME in result.index.names
+    assert CHAIN_NAME not in result.columns
+    assert DRAW_NAME not in result.columns
 
 
 @pytest.mark.parametrize(["spread_args", "rng_seed"], spread_args_and_rngs)

--- a/test/test_spread.py
+++ b/test/test_spread.py
@@ -1,0 +1,33 @@
+import pytest
+import arviz as az
+import polars as pl
+import numpy as np
+import pytest
+
+from polarbayes.spread import spread_draws, spread_draws_and_get_index_cols
+
+rugby_field_data = az.load_arviz_data("rugby_field")
+
+spread_args_and_rngs = [
+    [dict(var_names=["defs", "intercept"]), None],
+    [dict(num_samples=4), 42],
+    [dict(filter_vars="like", var_names=["def"]), None],
+    [dict(filter_vars="regex", var_names=["(def)|(intercept)"]), None],
+    [dict(), None],
+]
+
+
+@pytest.mark.parametrize(["spread_args", "rng_seed"], spread_args_and_rngs)
+def test_spread_wraps_spread_with_index(spread_args, rng_seed):
+    if rng_seed is not None:
+        rng_index = np.random.default_rng(rng_seed)
+        rng_no_index = np.random.default_rng(rng_seed)
+    else:
+        rng_index, rng_no_index = None, None
+    result, index = spread_draws_and_get_index_cols(
+        rugby_field_data, **spread_args, rng=rng_index
+    )
+    result_no_index = spread_draws(rugby_field_data, **spread_args, rng=rng_no_index)
+    assert result.equals(result_no_index)
+    for col in index:
+        assert col in result_no_index.columns

--- a/test/test_spread.py
+++ b/test/test_spread.py
@@ -26,7 +26,9 @@ def test_spread_wraps_spread_with_index(spread_args, rng_seed):
     result, index = spread_draws_and_get_index_cols(
         rugby_field_data, **spread_args, rng=rng_index
     )
-    result_no_index = spread_draws(rugby_field_data, **spread_args, rng=rng_no_index)
+    result_no_index = spread_draws(
+        rugby_field_data, **spread_args, rng=rng_no_index
+    )
     assert result.equals(result_no_index)
     for col in index:
         assert col in result_no_index.columns

--- a/test/test_spread.py
+++ b/test/test_spread.py
@@ -2,26 +2,68 @@ import arviz as az
 import numpy as np
 import pytest
 
-from polarbayes.spread import spread_draws, spread_draws_and_get_index_cols
+from polarbayes.schema import CHAIN_NAME, DRAW_NAME
+
+from polarbayes.spread import (
+    spread_draws_to_pandas_,
+    spread_draws,
+    spread_draws_and_get_index_cols,
+)
 
 rugby_field_data = az.load_arviz_data("rugby_field")
+
 
 spread_args_and_rngs = [
     [dict(var_names=["defs", "intercept"]), None],
     [dict(num_samples=4), 42],
     [dict(filter_vars="like", var_names=["def"]), None],
     [dict(filter_vars="regex", var_names=["(def)|(intercept)"]), None],
+    [
+        dict(
+            filter_vars="regex",
+            var_names=["(def)|(intercept)"],
+            combined=False,
+        ),
+        None,
+    ],
     [dict(), None],
 ]
 
 
+def get_n_identical_rngs(seed, n):
+    """
+    Get a tuple of n identically parametrized
+    numpy random number generators, or None
+    if the seed is None.
+    """
+    if seed is None:
+        return tuple([None] * n)
+    else:
+        return tuple(np.random.default_rng(seed) for _ in range(n))
+
+
+@pytest.mark.parametrize(["spread_args", "rng_seed"], spread_args_and_rngs)
+def test_spread_to_pandas(spread_args, rng_seed):
+    """
+    Test the spread_draws_to_pandas_ internal function
+    is a light wrapper of az.extract with the expected properties.
+    """
+    rng_spread, rng_extract = get_n_identical_rngs(rng_seed, 2)
+    result = spread_draws_to_pandas_(
+        rugby_field_data, **spread_args, rng=rng_spread
+    )
+    expected = az.extract(
+        rugby_field_data, **spread_args, rng=rng_extract
+    ).to_dataframe()
+    if spread_args.get("combined", True):
+        expected = expected.drop([CHAIN_NAME, DRAW_NAME], axis=1)
+
+    assert result.equals(expected)
+
+
 @pytest.mark.parametrize(["spread_args", "rng_seed"], spread_args_and_rngs)
 def test_spread_wraps_spread_with_index(spread_args, rng_seed):
-    if rng_seed is not None:
-        rng_index = np.random.default_rng(rng_seed)
-        rng_no_index = np.random.default_rng(rng_seed)
-    else:
-        rng_index, rng_no_index = None, None
+    rng_index, rng_no_index = get_n_identical_rngs(rng_seed, 2)
     result, index = spread_draws_and_get_index_cols(
         rugby_field_data, **spread_args, rng=rng_index
     )

--- a/test/test_spread.py
+++ b/test/test_spread.py
@@ -1,6 +1,5 @@
 import arviz as az
 import numpy as np
-import polars as pl
 import pytest
 
 from polarbayes.spread import spread_draws, spread_draws_and_get_index_cols


### PR DESCRIPTION
- Add tests for the `spread` module.
- Make spread output consistent with `schema.py` and gather output

## Additional changes
- Fixes ruff config